### PR TITLE
Error Handling

### DIFF
--- a/app/assets/javascripts/form.js
+++ b/app/assets/javascripts/form.js
@@ -24,6 +24,7 @@ document.addEventListener('turbolinks:load', () => {
       counter.style.color = "black";
     }
   });
+
   // カテゴリーフォームの追加関数
     // 変数定義
   const catParent = document.getElementById('catParent');

--- a/app/assets/stylesheets/_notification.scss
+++ b/app/assets/stylesheets/_notification.scss
@@ -1,0 +1,16 @@
+.notification {
+  .notice {
+    background-color: #3ccace;
+    color: #fff;
+    text-align: center;
+    padding: 10px 0;
+    font-size: 20px;
+  }
+    .alert {
+      background-color: tomato;
+      color: #fff;
+      text-align: center;
+      padding: 10px 0;
+      font-size: 20px;
+    }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
 @import 'mixins';
 @import 'font-awesome-sprockets';
 @import 'font-awesome';
+@import 'notification';
 @import 'header';
 @import 'footer';
 @import 'items';

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,8 +36,12 @@ class ItemsController < ApplicationController
   end
   
   def edit
-    @image = ItemImage.where(item_id: @item.id)
-    @count = @item.item_images.count
+    if current_user.id == @item.user_id
+      @image = ItemImage.where(item_id: @item.id)
+      @count = @item.item_images.count
+    else
+      redirect_to item_path(@item)
+    end
   end
   
   def update
@@ -70,15 +74,24 @@ class ItemsController < ApplicationController
   end
   
   def buypage
+    if current_user.id == @item.user_id
+      redirect_to item_path(@item)
+    elsif @item.is_deleted
+      redirect_to item_path(@item)
+    end
   end
 
   def buy
+    if @card.present?
     @item.update!(is_deleted: 1, buyer_id: current_user.id)
       charge = Payjp::Charge.create(
         amount: @item.price,
         customer: Payjp::Customer.retrieve(@card.customer_id),
         currency: 'jpy'
       )
+    else
+      render :buypage
+    end
   end
   
   private
@@ -91,30 +104,36 @@ class ItemsController < ApplicationController
   end
 
   def set_items
-    @item = Item.find(params[:id])
+    if params[:id].to_i  <= Item.all.length
+      @item = Item.find(params[:id])
+    else
+      redirect_to root_path
+    end
   end
 
   def set_card
     Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
     @card = Card.find_by(user_id: current_user.id)
-    customer = Payjp::Customer.retrieve(@card.customer_id)
-      @cards = customer.cards.retrieve(@card.card_id)
-      @brand = @cards.brand
-      case @brand
-      when "Visa"
-        @card_brand = "credit-card_visa.png"
-      when "MasterCard"
-        @card_brand = "credit-card_master.png"
-      when "JCB"
-        @card_brand = "credit-card_jcb.png"
-      when "American Express"
-        @card_brand = "credit-card_american.png"
-      when "Diners Club"
-        @card_brand = "credit-card_diners.png"
-      when "Discover"
-        @card_brand = "credit-card_discover.png"
-      end
-      @month = @cards.exp_month.to_s
-      @year = @cards.exp_year.to_s.slice(2,3)
+    if @card
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+        @cards = customer.cards.retrieve(@card.card_id)
+        @brand = @cards.brand
+        case @brand
+        when "Visa"
+          @card_brand = "credit-card_visa.png"
+        when "MasterCard"
+          @card_brand = "credit-card_master.png"
+        when "JCB"
+          @card_brand = "credit-card_jcb.png"
+        when "American Express"
+          @card_brand = "credit-card_american.png"
+        when "Diners Club"
+          @card_brand = "credit-card_diners.png"
+        when "Discover"
+          @card_brand = "credit-card_discover.png"
+        end
+        @month = @cards.exp_month.to_s
+        @year = @cards.exp_year.to_s.slice(2,3)
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,8 +22,9 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path
+      redirect_to item_path(@item), notice: '商品の出品に成功しました'
     else
+      flash.now[:alert] = '出品できませんでした。入力に不備があります'
       render :new
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,9 +22,8 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     if @item.save
-      redirect_to root_path, notice: '商品の出品に成功しました'
+      redirect_to root_path
     else
-      flash.now[:alert] = '出品に失敗しました'
       render :new
     end
   end

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -78,8 +78,12 @@
           .exhibition__box__image__form__required
             任意
         .exhibition__box__image__select
-          = f.select :size_id, options_for_select(Size.all.map {|p| [p.name, p.id]},selected: @item.size.id),{prompt: "選択してください"},{class:"exhibition__box__image__select--category"}
-          %iselect.exhibition__box__image__select__arrow.fas.fa-chevron-down.fa-lg
+          - if @item.size_id
+            = f.select :size_id, options_for_select(Size.all.map {|p| [p.name, p.id]},selected: @item.size.id),{prompt: "選択してください"},{class:"exhibition__box__image__select--category"}
+            %iselect.exhibition__box__image__select__arrow.fas.fa-chevron-down.fa-lg
+          - else
+            = f.select :size_id, options_for_select(Size.all.map {|p| [p.name, p.id]}),{prompt: "選択してください"},{class:"exhibition__box__image__select--category"}
+            %iselect.exhibition__box__image__select__arrow.fas.fa-chevron-down.fa-lg
         .exhibition__box__image__line
           .exhibition__box__image__line__bland
             ブランド
@@ -130,8 +134,8 @@
           .exhibition__box__image__carry__required
             必須
         .exhibition__box__image__select
-        = f.select :delivery_day_id, options_for_select(DeliveryDay.all.map {|p| [p.name, p.id]},selected: @item.delivery_day.id),{prompt: "選択してください"},{class:"exhibition__box__image__select--category"}
-        %iselect.exhibition__box__image__select__arrow.fas.fa-chevron-down.fa-lg
+          = f.select :delivery_day_id, options_for_select(DeliveryDay.all.map {|p| [p.name, p.id]},selected: @item.delivery_day.id),{prompt: "選択してください"},{class:"exhibition__box__image__select--category"}
+          %iselect.exhibition__box__image__select__arrow.fas.fa-chevron-down.fa-lg
       .exhibition__box__image
         .exhibition__box__image__details
           .exhibition__box__image__details__goods

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -107,14 +107,5 @@
     .banner__inner__icon
       = render partial: "top_banner"
 
-- if user_signed_in?
-  = link_to new_item_path do
-    .putup__btn
-      %span.putup__btn__text> 出品する
-      = image_tag 'icon_camera.png', alt: '出品する', height: '', width: '', class: 'putup__btn__icon'
-- else
-  = link_to new_user_session_path do
-    .putup__btn
-      %span.putup__btn__text> 出品する
-      = image_tag 'icon_camera.png', alt: '出品する', height: '', width: '', class: 'putup__btn__icon'
+
 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,3 +1,4 @@
+= render partial: "modules/notification"
 .exhibition
   .exhibition__header
     = image_tag 'logo.png', size:"140x50", class:"exhibition__header__frima"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -11,7 +11,7 @@
       %i.fa.fa-angle-right
     %li
       = @item.name
-
+= render partial:'modules/notification'
 .main
   .content
     .top-content

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -91,3 +91,13 @@
       .footer-logo
         = image_tag 'logo-white.png', size: '160x46', class:"footer-logo--image"
       %p © FURIMA
+    - if user_signed_in?
+      = link_to new_item_path do
+        .putup__btn
+          %span.putup__btn__text> 出品する
+          = image_tag 'icon_camera.png', alt: '出品する', height: '', width: '', class: 'putup__btn__icon'
+    - else
+      = link_to new_user_session_path do
+        .putup__btn
+          %span.putup__btn__text> 出品する
+          = image_tag 'icon_camera.png', alt: '出品する', height: '', width: '', class: 'putup__btn__icon'

--- a/app/views/modules/_notification.html.haml
+++ b/app/views/modules/_notification.html.haml
@@ -1,0 +1,3 @@
+.notification
+  - flash.each do |key, value|
+    = content_tag :div, value, class: key

--- a/app/views/users/nowonsale.html.haml
+++ b/app/views/users/nowonsale.html.haml
@@ -4,19 +4,12 @@
       .mypage-card
       .container
         %h1.title 出品中の商品
-        .tabs
-          .tab
-            %p 出品中
-          .tab
-            %p 取引中
-          .tab
-            %p 取引終了
         %ul
           - @items.each do |item|
             %li
               .item
                 .image-box
-                  = image_tag 'a001.png', size: '50x50'
+                  = image_tag "#{item.item_images[0].image}", size: '100x100'
                 .item-name
                   %p=item.name
                 .icon


### PR DESCRIPTION
# What
クレジットカード未登録ユーザーは購入アクションを取れないように変更。renderされる。
存在しないitem.idをURLに直打ちした場合、rootにリダイレクトされるよう変更。
出品者は購入ページにアクセスできないように設定。
is_deleted: trueの商品は購入ページにアクセスできないように設定。
item#createのflash _noticeを削除。使用していなかったため。
出品者以外はitem#editにアクセスできないように変更。


# Why
不正アクセスを防ぐため。