### PR TITLE
debug items#set_items, items#show

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -111,10 +111,11 @@ class ItemsController < ApplicationController
   end
 
   def set_items
-    if params[:id].to_i <= Item.pluck(:id).max
+    item_ids = Item.pluck(:id)
+    if (params[:id].to_i <= item_ids.max) && (item_ids.include?(params[:id].to_i))
       @item = Item.find(params[:id])
     else
-      redirect_to root_path
+      redirect_to list_items_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,8 +33,9 @@ class ItemsController < ApplicationController
   def show
     @images = ItemImage.where(item_id: @item.id)
     @image = ItemImage.where(item_id: @item.id).first
-    @beforeitem = Item.find_by(id: @item.id - 1) 
-    @nextitem = Item.find_by(id: @item.id + 1)
+    item_ids = Item.pluck(:id)
+    @prevItem = item_ids.select {|id| id < @item.id}.max
+    @nextItem = item_ids.select {|id| id > @item.id}.min
   end
   
   def edit
@@ -110,7 +111,7 @@ class ItemsController < ApplicationController
   end
 
   def set_items
-    if params[:id].to_i  <= Item.all.length
+    if params[:id].to_i <= Item.pluck(:id).max
       @item = Item.find(params[:id])
     else
       redirect_to root_path

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -124,17 +124,13 @@
 
     %ul.links
       %li
-        - if @beforeitem
+        - if @prevItem
           %i.fa.fa-angle-left
-          = link_to "前の商品", item_path(@item.id - 1)
-        - else
-          = link_to "前の商品", item_path(@item)
+          = link_to "前の商品", item_path(@prevItem)
       %li
-        - if @nextitem
-          = link_to "次の商品", item_path(@item.id + 1) 
+        - if @nextItem
+          = link_to "次の商品", item_path(@nextItem) 
           %i.fa.fa-angle-right
-        - else 
-          = link_to "次の商品", item_path(@item)
     .related-items
       = link_to "#{@item.category.root.name}をもっと見る", category_path(@item.category.root.id)
       .item-lists


### PR DESCRIPTION
# what
最新のitem詳細ページにアクセスするとリダイレクトされる不具合を修正。
item詳細ページにおける前のアイテム、次のアイテムのリンクを修正。

# why
エラーを表示させないため。